### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MondoKit
 
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/MondoKit.svg)](https://img.shields.io/cocoapods/v/MondoKit.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/MondoKit.svg)](https://img.shields.io/cocoapods/v/MondoKit.svg)
 [![License](https://img.shields.io/cocoapods/l/MondoKit.svg?style=flat)](http://cocoapods.org/pods/MondoKit)
 [![Platform](https://img.shields.io/cocoapods/p/MondoKit.svg?style=flat)](http://cocoapods.org/pods/MondoKit)
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
